### PR TITLE
Fix: Use / instead of DIRECTORY_SEPARATOR

### DIFF
--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Api/Jobs.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Api/Jobs.php
@@ -152,7 +152,7 @@ class Jobs extends CoverallsApi
             'multipart' => [
                 [
                     'name' => $filename,
-                    'contents' => fopen($path, 'r'),
+                    'contents' => file_get_contents($path),
                 ],
             ],
         ];

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Collector/CloverXmlCoverageCollector.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Collector/CloverXmlCoverageCollector.php
@@ -31,7 +31,7 @@ class CloverXmlCoverageCollector
      */
     public function collect(\SimpleXMLElement $xml, $rootDir)
     {
-        $root = rtrim($rootDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        $root = rtrim($rootDir, '/') . '/';
 
         if (!isset($this->jsonFile)) {
             $this->jsonFile = new JsonFile();
@@ -93,7 +93,7 @@ class CloverXmlCoverageCollector
             return;
         }
 
-        if ($root !== DIRECTORY_SEPARATOR) {
+        if ($root !== '/') {
             $filename = str_replace($root, '', $absolutePath);
         } else {
             $filename = $absolutePath;

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Command/CoverallsV1JobsCommand.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Command/CoverallsV1JobsCommand.php
@@ -135,7 +135,7 @@ class CoverallsV1JobsCommand extends Command
     {
         $coverallsYmlPath = $input->getOption('config');
 
-        $ymlPath = $this->rootDir . DIRECTORY_SEPARATOR . $coverallsYmlPath;
+        $ymlPath = $this->rootDir . '/'. $coverallsYmlPath;
         $configurator = new Configurator();
 
         return $configurator

--- a/src/Satooshi/Component/File/Path.php
+++ b/src/Satooshi/Component/File/Path.php
@@ -26,7 +26,7 @@ class Path
             return !preg_match('/^[a-z]+\:\\\\/i', $path);
         }
 
-        return strpos($path, DIRECTORY_SEPARATOR) !== 0;
+        return strpos($path, '/') !== 0;
     }
 
     /**
@@ -44,7 +44,7 @@ class Path
         }
 
         if ($this->isRelativePath($path)) {
-            return $rootDir . DIRECTORY_SEPARATOR . $path;
+            return $rootDir . '/'. $path;
         }
 
         return $path;
@@ -65,7 +65,7 @@ class Path
         }
 
         if ($this->isRelativePath($path)) {
-            return realpath($rootDir . DIRECTORY_SEPARATOR . $path);
+            return realpath($rootDir . '/' . $path);
         }
 
         return realpath($path);
@@ -86,7 +86,7 @@ class Path
         }
 
         if ($this->isRelativePath($path)) {
-            return realpath($rootDir . DIRECTORY_SEPARATOR . dirname($path));
+            return realpath($rootDir . '/'. dirname($path));
         }
 
         return realpath(dirname($path));
@@ -108,7 +108,7 @@ class Path
             return false;
         }
 
-        return $realDir . DIRECTORY_SEPARATOR . basename($path);
+        return $realDir . '/'. basename($path);
     }
 
     /**

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Api/JobsTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Api/JobsTest.php
@@ -89,7 +89,7 @@ class JobsTest extends ProjectTestCase
                 return !empty($options['multipart'][0]['name'])
                     && !empty($options['multipart'][0]['contents'])
                     && $options['multipart'][0]['name'] === $filename
-                    && is_resource($options['multipart'][0]['contents']);
+                    && is_string($options['multipart'][0]['contents']);
             }))
             ->willReturn($response)
             ->shouldBeCalled();

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Collector/CloverXmlCoverageCollectorTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Collector/CloverXmlCoverageCollectorTest.php
@@ -120,7 +120,7 @@ XML;
         $sourceFiles = $jsonFile->getSourceFiles();
 
         $name1 = 'test.php';
-        $path1 = $this->srcDir . DIRECTORY_SEPARATOR . $name1;
+        $path1 = $this->srcDir . '/'. $name1;
 
         $this->assertArrayHasKey($path1, $sourceFiles);
         $this->assertSourceFileTest1($sourceFiles[$path1]);
@@ -135,7 +135,7 @@ XML;
         $sourceFiles = $jsonFile->getSourceFiles();
 
         $name2 = 'test2.php';
-        $path2 = $this->srcDir . DIRECTORY_SEPARATOR . $name2;
+        $path2 = $this->srcDir . '/'. $name2;
 
         $this->assertArrayHasKey($path2, $sourceFiles);
         $this->assertSourceFileTest2($sourceFiles[$path2]);
@@ -149,7 +149,7 @@ XML;
     public function shouldCollectUnderRootDir()
     {
         $xml = $this->createCloverXml();
-        $jsonFile = $this->object->collect($xml, DIRECTORY_SEPARATOR);
+        $jsonFile = $this->object->collect($xml, '/');
 
         $this->assertSame($jsonFile, $this->object->getJsonFile());
         $this->assertJsonFile($jsonFile, null, null, null, null, '2013-04-13 10:28:13 +0000');
@@ -179,7 +179,7 @@ XML;
         $sourceFiles = $jsonFile->getSourceFiles();
 
         $name1 = 'test.php';
-        $path1 = $this->srcDir . DIRECTORY_SEPARATOR . $name1;
+        $path1 = $this->srcDir . '/'. $name1;
 
         $this->assertArrayHasKey($path1, $sourceFiles);
         $this->assertSourceFileTest1UnderRootDir($sourceFiles[$path1]);
@@ -194,7 +194,7 @@ XML;
         $sourceFiles = $jsonFile->getSourceFiles();
 
         $name2 = 'test2.php';
-        $path2 = $this->srcDir . DIRECTORY_SEPARATOR . $name2;
+        $path2 = $this->srcDir . '/'. $name2;
 
         $this->assertArrayHasKey($path2, $sourceFiles);
         $this->assertSourceFileTest2UnderRootDir($sourceFiles[$path2]);
@@ -223,7 +223,7 @@ XML;
     protected function assertSourceFileTest1(SourceFile $sourceFile)
     {
         $name1 = 'test.php';
-        $path1 = $this->srcDir . DIRECTORY_SEPARATOR . $name1;
+        $path1 = $this->srcDir . '/'. $name1;
         $fileLines1 = 9;
         $coverage1 = array_fill(0, $fileLines1, null);
         $coverage1[6] = 3;
@@ -235,7 +235,7 @@ XML;
     protected function assertSourceFileTest2(SourceFile $sourceFile)
     {
         $name2 = 'test2.php';
-        $path2 = $this->srcDir . DIRECTORY_SEPARATOR . $name2;
+        $path2 = $this->srcDir . '/'. $name2;
         $fileLines2 = 10;
         $coverage2 = array_fill(0, $fileLines2, null);
         $coverage2[7] = 0;
@@ -247,7 +247,7 @@ XML;
     protected function assertSourceFileTest1UnderRootDir(SourceFile $sourceFile)
     {
         $name1 = 'test.php';
-        $path1 = $this->srcDir . DIRECTORY_SEPARATOR . $name1;
+        $path1 = $this->srcDir . '/'. $name1;
         $fileLines1 = 9;
         $coverage1 = array_fill(0, $fileLines1, null);
         $coverage1[6] = 3;
@@ -259,7 +259,7 @@ XML;
     protected function assertSourceFileTest2UnderRootDir(SourceFile $sourceFile)
     {
         $name2 = 'test2.php';
-        $path2 = $this->srcDir . DIRECTORY_SEPARATOR . $name2;
+        $path2 = $this->srcDir . '/'. $name2;
         $fileLines2 = 10;
         $coverage2 = array_fill(0, $fileLines2, null);
         $coverage2[7] = 0;

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Config/ConfiguratorTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Config/ConfiguratorTest.php
@@ -99,6 +99,11 @@ class ConfiguratorTest extends ProjectTestCase
      */
     public function throwInvalidConfigurationExceptionOnLoadEmptyYmlIfJsonPathDirNotWritable()
     {
+        if ($this->isWindowsOS()) {
+            // On Windows read-only attribute on dir applies to files in dir, but not the dir itself.
+            $this->markTestSkipped('Unable to run on Windows');
+        }
+
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath, true);
 
         $path = realpath(__DIR__ . '/yaml/dummy.yml');
@@ -320,5 +325,16 @@ class ConfiguratorTest extends ProjectTestCase
         $path = realpath(__DIR__ . '/yaml/exclude_no_stmt_invalid.yml');
 
         $this->object->load($path, $this->rootDir);
+    }
+
+    private function isWindowsOS()
+    {
+        static $isWindows;
+
+        if ($isWindows === null) {
+            $isWindows = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
+        }
+
+        return $isWindows;
     }
 }

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Config/ConfiguratorTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Config/ConfiguratorTest.php
@@ -41,8 +41,8 @@ class ConfiguratorTest extends ProjectTestCase
 
     protected function assertConfiguration(Configuration $config, array $cloverXml, $jsonPath, $excludeNoStatements = false)
     {
-        $this->assertSame($cloverXml, $config->getCloverXmlPaths());
-        $this->assertSame($jsonPath, $config->getJsonPath());
+        $this->assertSamePaths($cloverXml, $config->getCloverXmlPaths());
+        $this->assertSamePath($jsonPath, $config->getJsonPath());
         $this->assertSame($excludeNoStatements, $config->isExcludeNoStatements());
     }
 

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Entity/JsonFileTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Entity/JsonFileTest.php
@@ -29,7 +29,7 @@ class JsonFileTest extends ProjectTestCase
     protected function createSourceFile()
     {
         $filename = 'test.php';
-        $path = $this->srcDir . DIRECTORY_SEPARATOR . $filename;
+        $path = $this->srcDir . '/'. $filename;
 
         return new SourceFile($path, $filename);
     }
@@ -699,7 +699,7 @@ XML;
      */
     public function shouldExcludeNoStatementsFiles()
     {
-        $srcDir = $this->srcDir . DIRECTORY_SEPARATOR;
+        $srcDir = $this->srcDir . '/';
 
         $object = $this->collectJsonFile();
 

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Entity/SourceFileTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Entity/SourceFileTest.php
@@ -19,7 +19,7 @@ class SourceFileTest extends ProjectTestCase
         $this->setUpDir($this->projectDir);
 
         $this->filename = 'test.php';
-        $this->path = $this->srcDir . DIRECTORY_SEPARATOR . $this->filename;
+        $this->path = $this->srcDir . '/'. $this->filename;
 
         $this->object = new SourceFile($this->path, $this->filename);
     }

--- a/tests/Satooshi/Component/File/PathTest.php
+++ b/tests/Satooshi/Component/File/PathTest.php
@@ -2,12 +2,14 @@
 
 namespace Satooshi\Component\File;
 
+use Satooshi\ProjectTestCase;
+
 /**
  * @covers \Satooshi\Component\File\Path
  *
  * @author Kitamura Satoshi <with.no.parachute@gmail.com>
  */
-class PathTest extends \PHPUnit_Framework_TestCase
+class PathTest extends ProjectTestCase
 {
     protected function setUp()
     {
@@ -26,22 +28,6 @@ class PathTest extends \PHPUnit_Framework_TestCase
         $this->rmFile($this->unwritablePath);
 
         $this->rmDir($this->unwritableDir);
-    }
-
-    protected function rmFile($file)
-    {
-        if (is_file($file)) {
-            chmod($file, 0777);
-            unlink($file);
-        }
-    }
-
-    protected function rmDir($dir)
-    {
-        if (is_dir($dir)) {
-            chmod($dir, 0777);
-            rmdir($dir);
-        }
     }
 
     protected function touchUnreadableFile()

--- a/tests/Satooshi/Component/File/PathTest.php
+++ b/tests/Satooshi/Component/File/PathTest.php
@@ -121,7 +121,7 @@ class PathTest extends ProjectTestCase
     {
         $rootDir = '/path/to/dir';
 
-        $expected = $rootDir . DIRECTORY_SEPARATOR . $path;
+        $expected = $rootDir . '/'. $path;
 
         $this->assertSame($expected, $this->object->toAbsolutePath($path, $rootDir));
     }
@@ -160,7 +160,7 @@ class PathTest extends ProjectTestCase
     {
         $rootDir = __DIR__;
 
-        $expected = realpath($rootDir . DIRECTORY_SEPARATOR . $path);
+        $expected = realpath($rootDir . '/'. $path);
 
         $this->assertSame($expected, $this->object->getRealPath($path, $rootDir));
     }
@@ -199,7 +199,7 @@ class PathTest extends ProjectTestCase
         $path = '';
         $rootDir = __DIR__;
 
-        $expected = realpath($rootDir . DIRECTORY_SEPARATOR . $path);
+        $expected = realpath($rootDir . '/'. $path);
 
         $this->assertSame($expected, $this->object->getRealDir($path, $rootDir));
     }
@@ -238,7 +238,7 @@ class PathTest extends ProjectTestCase
         $path = 'test.txt';
         $rootDir = __DIR__;
 
-        $expected = $rootDir . DIRECTORY_SEPARATOR . $path;
+        $expected = $rootDir . '/'. $path;
 
         $this->assertSame($expected, $this->object->getRealWritingFilePath($path, $rootDir));
     }

--- a/tests/Satooshi/ProjectTestCase.php
+++ b/tests/Satooshi/ProjectTestCase.php
@@ -58,7 +58,7 @@ class ProjectTestCase extends \PHPUnit_Framework_TestCase
     protected function rmFile($file)
     {
         if (is_file($file)) {
-            chmod(dirname($file), 0777);
+            chmod($file, 0777);
             unlink($file);
         }
     }

--- a/tests/Satooshi/ProjectTestCase.php
+++ b/tests/Satooshi/ProjectTestCase.php
@@ -58,7 +58,9 @@ class ProjectTestCase extends \PHPUnit_Framework_TestCase
     protected function rmFile($file)
     {
         if (is_file($file)) {
-            chmod($file, 0777);
+            // we try to unlock file, for that, we might need different permissions:
+            chmod(dirname($file), 0777); // on unix
+            chmod($file, 0777); // on Windows
             unlink($file);
         }
     }

--- a/tests/Satooshi/ProjectTestCase.php
+++ b/tests/Satooshi/ProjectTestCase.php
@@ -70,4 +70,26 @@ class ProjectTestCase extends \PHPUnit_Framework_TestCase
             rmdir($dir);
         }
     }
+
+    protected function normalizePath($path)
+    {
+        return strtr(DIRECTORY_SEPARATOR, '/', $path);
+    }
+
+    protected function assertSamePath($expected, $input, $msg = null)
+    {
+        $this->assertSame(
+            $this->normalizePath($expected),
+            $this->normalizePath($input),
+            $msg
+        );
+    }
+
+    protected function assertSamePaths(array $expected, array $input, $msg = null)
+    {
+        $expected = array_map(function ($path) { return $this->normalizePath($path); }, $expected);
+        $input = array_map(function ($path) { return $this->normalizePath($path); }, $input);
+
+        $this->assertSame($expected, $input, $msg);
+    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,4 +4,4 @@ if (!class_exists('PHPUnit_Framework_TestCase')) {
     class PHPUnit_Framework_TestCase extends \PHPUnit\Framework\TestCase {}
 }
 
-require __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
+require __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
This PR

* [x] uses `/` instead of the `DIRECTORY_SEPARATOR` constant

Follows https://github.com/satooshi/php-coveralls/pull/223#pullrequestreview-53360754.